### PR TITLE
Bump transitive gems to patch Dependabot security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.0.1)
     colorator (1.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -81,7 +81,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.18.1)
+    json (2.20.0)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
Resolves 5 advisories flagged by Dependabot on the default branch, all in transitive dependencies (constraints in Gemfile already allow the patched versions):

- addressable 2.8.8 -> 2.9.0  (CVE-2026-35611, ReDoS in templates)
- json 2.18.1 -> 2.20.0       (CVE-2026-33210, format string injection)
- concurrent-ruby 1.3.6 -> 1.3.7
    (CVE-2026-54904 / 54905 / 54906, lock corruption)

Verified with bundler-audit (advisory DB 2026-06-24): no vulnerabilities remaining. Lockfile edited directly because local Ruby (2.6) predates the bundler 2.6.1 that created the lockfile; should be confirmed with `bundle install` on a Ruby >= 3.1 environment.